### PR TITLE
Add shutdown method to ExtensionBootstrap

### DIFF
--- a/src/main/java/net/hollowcube/minestom/extensions/ExtensionBootstrap.java
+++ b/src/main/java/net/hollowcube/minestom/extensions/ExtensionBootstrap.java
@@ -40,4 +40,8 @@ public final class ExtensionBootstrap {
         extensions.gotoPostInit();
     }
 
+    public void shutdown() {
+        extensions.shutdown();
+    }
+
 }

--- a/src/main/java/net/hollowcube/minestom/extensions/ExtensionBootstrap.java
+++ b/src/main/java/net/hollowcube/minestom/extensions/ExtensionBootstrap.java
@@ -25,6 +25,7 @@ public final class ExtensionBootstrap {
     private ExtensionBootstrap(@NotNull MinecraftServer server) {
         this.server = server;
         extensions = new ExtensionManager(MinecraftServer.process());
+        MinecraftServer.getSchedulerManager().buildShutdownTask(extensions::shutdown);
 
         extensions.start();
         extensions.gotoPreInit();


### PR DESCRIPTION
Needed to properly unload extensions on shutdown. This does not (but could easily be added if you think it should) add a shutdown task to automatically run it. 